### PR TITLE
Support local hosts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "exolnet/envoy": "^1.100.0"
     },
     "require-dev": {
+        "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^5.7.27",
         "squizlabs/php_codesniffer": "^3.3.2"
     },

--- a/src/ConfigEnvironment.php
+++ b/src/ConfigEnvironment.php
@@ -112,7 +112,7 @@ class ConfigEnvironment extends Config
             $host = $this->get('ssh_user') .'@'. $host;
         }
 
-        if (in_array($host, static::LOCAL_HOSTS)) {
+        if ($this->isLocalHost($host)) {
             return $host;
         }
 
@@ -182,6 +182,10 @@ class ConfigEnvironment extends Config
             throw new EnvoyException('SSH host is not defined.');
         }
 
+        if (! $this->get('ssh_user') && ! $this->isLocalHost()) {
+            throw new EnvoyException('SSH user is not defined.');
+        }
+
         if (! $this->get('deploy_path')) {
             throw new EnvoyException('Deploy path is not defined.');
         }
@@ -193,5 +197,14 @@ class ConfigEnvironment extends Config
         if (! $this->get('cron_mailto') && $this->get('cron_jobs')) {
             throw new EnvoyException('Cron MAILTO is not defined.');
         }
+    }
+
+    /**
+     * @param null $host
+     * @return bool
+     */
+    protected function isLocalHost($host = null)
+    {
+        return in_array($host ?? $this->get('ssh_host'), static::LOCAL_HOSTS);
     }
 }

--- a/src/ConfigEnvironment.php
+++ b/src/ConfigEnvironment.php
@@ -7,6 +7,11 @@ use Exolnet\Envoy\Exceptions\EnvoyException;
 class ConfigEnvironment extends Config
 {
     /**
+     * @var array
+     */
+    const LOCAL_HOSTS = ['local', 'localhost', '127.0.0.1'];
+
+    /**
      * @var string
      */
     protected $name;
@@ -101,13 +106,23 @@ class ConfigEnvironment extends Config
      */
     public function buildServerString()
     {
+        $host = $this->get('ssh_host');
+
+        if ($this->get('ssh_user')) {
+            $host = $this->get('ssh_user') .'@'. $host;
+        }
+
+        if (in_array($host, static::LOCAL_HOSTS)) {
+            return $host;
+        }
+
         $options = '-qA'; // Same as '-q -A'
 
-        if ($this->has('ssh_options')) {
+        if ($this->get('ssh_options')) {
             $options .= ' '. trim($this->get('ssh_options'));
         }
 
-        return $options .' '. $this->get('ssh_user') .'@'. $this->get('ssh_host');
+        return $options .' '. $host;
     }
 
     /**
@@ -165,10 +180,6 @@ class ConfigEnvironment extends Config
     {
         if (! $this->get('ssh_host')) {
             throw new EnvoyException('SSH host is not defined.');
-        }
-
-        if (! $this->get('ssh_user')) {
-            throw new EnvoyException('SSH user is not defined.');
         }
 
         if (! $this->get('deploy_path')) {

--- a/tests/Unit/ConfigEnvironmentTest.php
+++ b/tests/Unit/ConfigEnvironmentTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Exolnet\Envoy\Tests\Unit;
+
+use Exolnet\Envoy\ConfigContext;
+use Exolnet\Envoy\ConfigEnvironment;
+use Generator;
+use Mockery as m;
+
+class ConfigEnvironmentTest extends UnitTest
+{
+    /**
+     * @var array
+     */
+    const BASE_CONFIG = [
+        'ssh_host' => 'hostname',
+        'ssh_user' => 'user',
+        'deploy_path' => '/deployment/path',
+        'repository_url' => 'ssh://git@hostname/repository.git',
+    ];
+
+    /**
+     * @var \Exolnet\Envoy\ConfigContext|\Mockery\LegacyMockInterface|\Mockery\MockInterface
+     */
+    protected $context;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->context = m::mock(ConfigContext::class);
+
+        $this->context->shouldReceive('get')->andReturn(null);
+    }
+
+
+    /**
+     * @return void
+     */
+    public function testEnvoyConfigurationCanBeCompiled(): void
+    {
+        $config = new ConfigEnvironment('foo', static::BASE_CONFIG, $this->context);
+
+        $this->assertInstanceOf(ConfigEnvironment::class, $config);
+    }
+
+    /**
+     * @return void
+     * @dataProvider provideTestBuildServerString
+     */
+    public function testBuildServerString($host, $user, $options, $expected): void
+    {
+        $overwrites = [
+            'ssh_host' => $host,
+            'ssh_user' => $user,
+            'ssh_options' => $options,
+        ];
+
+        $config = new ConfigEnvironment('foo', $overwrites + static::BASE_CONFIG, $this->context);
+
+        $this->assertEquals($expected, $config->buildServerString());
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function provideTestBuildServerString(): Generator
+    {
+        yield ['127.0.0.1', '', '', '127.0.0.1'];
+        yield ['hostname', '', '', '-qA hostname'];
+        yield ['hostname', 'user', '', '-qA user@hostname'];
+        yield ['hostname', '', '-p', '-qA -p hostname'];
+        yield ['hostname', 'user', '-p', '-qA -p user@hostname'];
+    }
+}


### PR DESCRIPTION
Right now, it's impossible to deploy an application locally even if Laravel Envoy supports it (see https://github.com/laravel/envoy/blob/f55eff84be7f1704ffea47af3d2f65d631153d2b/src/RemoteProcessor.php#L32)

This PR update the method `buildServerString` to support it.