### PR TITLE
feat: make sure the release directory exist before executing the symlink

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -305,6 +305,11 @@
 @task('deploy:symlink')
     echo "Linking directory {{ $releasePath }} to {{ $currentPath }}"
 
+    if [ ! -d "{{ $releasePath }}" ]; then
+        echo "Release directory not found." 1>&2
+        exit 1
+    fi
+
     ln -srfn "{{ $releasePath }}" "{{ $currentPath }}"
 @endtask
 


### PR DESCRIPTION
# Description

This change is to make sure the release passed to the deploy:symlink exist. 

# Context

During the change a php version of site, the deploy:complete step was run with a wrong release number creating a symlink pointing to a non existant folder.