### PR TITLE
feat: remove laravel 11 support and change php version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.5]
+        php: [8.3, 8.4, 8.5]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
+        php: [8.4, 8.5]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "exolnet/envoy": "^1.110.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "exolnet/envoy": "^1.110.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request updates the minimum required PHP version for the project and adjusts the test workflow accordingly. The main focus is to ensure compatibility with PHP 8.4 and above.

Dependency and compatibility updates:

* Updated the PHP requirement in `composer.json` to require PHP version 8.4 or higher, dropping support for earlier versions.

Continuous integration workflow changes:

* Modified the GitHub Actions test matrix in `.github/workflows/tests.yml` to only run tests against PHP 8.4 and 8.5, removing 8.2 and 8.3 from the test suite.

Ref: #59909